### PR TITLE
Cast lists using to_json filter for Ansible v2

### DIFF
--- a/templates/config/_macros.j2
+++ b/templates/config/_macros.j2
@@ -58,6 +58,6 @@
     {%- elif value is number -%}
         {{ value }}
     {%- else -%}
-        {{ value }}
+        {{ value | to_json }}
     {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
Ansible 2.0 represents lists with a unicode prefix.  By casting to JSON
we can avoid this issue.  This is also compatibile with Ansible v1.
